### PR TITLE
FOGL-8312 : Implemented plugin_start function

### DIFF
--- a/include/kafka.h
+++ b/include/kafka.h
@@ -27,6 +27,7 @@ class Kafka
 		uint32_t		send(const std::vector<Reading *> readings);
 		void			pollThread();
 		void			sendJSONObjects(bool arg) { m_objects = arg; };
+		void			connect();
 		inline void		success() { m_sent++; };
 		inline void		setErrorStatus(bool isError) { m_error = isError; };
 		static void 		logCallback(const rd_kafka_t *rk, int level, const char *facility, const char *buf);

--- a/kafka.cpp
+++ b/kafka.cpp
@@ -87,7 +87,6 @@ Kafka::Kafka(ConfigCategory*& configData ) : m_running(true), m_objects(false)
 	try
 	{
 		m_error = false;
-		char	errstr[512];
 		m_topic = configData->getValue("topic");
 		m_conf = rd_kafka_conf_new();
 
@@ -112,20 +111,6 @@ Kafka::Kafka(ConfigCategory*& configData ) : m_running(true), m_objects(false)
 
 		rd_kafka_conf_set_dr_msg_cb(m_conf, dr_msg_cb);
 		rd_kafka_conf_set_opaque(m_conf, this);
-		m_rk = rd_kafka_new(RD_KAFKA_PRODUCER, m_conf, errstr, sizeof(errstr));
-		if (!m_rk)
-		{
-			Logger::getLogger()->fatal(errstr);
-			throw exception();
-		}
-		m_rkt = rd_kafka_topic_new(m_rk, m_topic.c_str(), NULL);
-			if (!m_rkt) {
-					Logger::getLogger()->fatal("Failed to create topic object: %s\n",
-							rd_kafka_err2str(rd_kafka_last_error()));
-					rd_kafka_destroy(m_rk);
-					throw exception();
-			}
-		m_thread = new thread(pollThreadWrapper, this);
 	}
 	catch(std::exception &ex)
 	{
@@ -134,6 +119,29 @@ Kafka::Kafka(ConfigCategory*& configData ) : m_running(true), m_objects(false)
 
 }
 
+/**
+ * Establish connection with Kafka broker
+ *
+ */
+void Kafka::connect()
+{
+	char errstr[512];
+	m_rk = rd_kafka_new(RD_KAFKA_PRODUCER, m_conf, errstr, sizeof(errstr));
+	if (!m_rk)
+	{
+		Logger::getLogger()->error(errstr);
+		return;
+	}
+	m_rkt = rd_kafka_topic_new(m_rk, m_topic.c_str(), NULL);
+	if (!m_rkt)
+	{
+		Logger::getLogger()->error("Failed to create topic object: %s\n", rd_kafka_err2str(rd_kafka_last_error()));
+		rd_kafka_destroy(m_rk);
+		return;
+	}
+	m_thread = new thread(pollThreadWrapper, this);
+
+}
 
 /**
  * certificateStoreLocation
@@ -364,12 +372,20 @@ void Kafka::applyConfig_SSL(ConfigCategory*& configData, const string& kafkaSecu
  */
 Kafka::~Kafka()
 {
-	rd_kafka_flush(m_rk, 1000);
-	rd_kafka_topic_destroy(m_rkt);
+	if(m_rk && m_rkt)
+	{
+		rd_kafka_flush(m_rk, 1000);
+		rd_kafka_topic_destroy(m_rkt);
+		rd_kafka_destroy(m_rk);
+	}
+	
 	m_running = false;
-	rd_kafka_destroy(m_rk);
-	m_thread->join();
-	delete m_thread;
+	
+	if (m_thread)
+	{
+		m_thread->join();
+		delete m_thread;
+	}
 }
 
 /**
@@ -423,9 +439,13 @@ Kafka::pollThread()
 uint32_t
 Kafka::send(const vector<Reading *> readings)
 {
-
-	Logger::getLogger()->debug("Kafka send called");
 	m_sent = 0;
+	// Check if kafka connection and topic is valid
+	if (!m_rk && !m_rkt)
+	{
+		Logger::getLogger()->warn("Data is not sent due to invalid Kafka connection or topic");
+		return m_sent;
+	}
 
 	int cnt = 0;
 	for (auto it = readings.cbegin(); it != readings.cend(); ++it)

--- a/kafka.cpp
+++ b/kafka.cpp
@@ -439,6 +439,8 @@ Kafka::pollThread()
 uint32_t
 Kafka::send(const vector<Reading *> readings)
 {
+
+	Logger::getLogger()->debug("Kafka send called");
 	m_sent = 0;
 	// Check if kafka connection and topic is valid
 	if (!m_rk && !m_rkt)

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -210,6 +210,7 @@ PLUGIN_HANDLE plugin_start(PLUGIN_HANDLE handle)
 {
 	Kafka* kafka = (Kafka *)handle;
 	kafka->connect();
+	return handle;
 }
 /**
  * Send Readings data to historian server

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -202,6 +202,16 @@ PLUGIN_HANDLE plugin_init(ConfigCategory* configData)
 }
 
 /**
+ * Start plugin
+ *
+ *	@param handle	The plugin handle returned from plugin_init
+ */
+PLUGIN_HANDLE plugin_start(PLUGIN_HANDLE handle)
+{
+	Kafka* kafka = (Kafka *)handle;
+	kafka->connect();
+}
+/**
  * Send Readings data to historian server
  */
 uint32_t plugin_send(const PLUGIN_HANDLE handle,


### PR DESCRIPTION
Logic of connecting to Kafka broker was in the constructor for the class. So plugin was trying to connect to Kafka broker even when plugin manager was loading plugins in disabled mode as well. I moved this logic to plugin_start function. So that plugin will not attempt any connection to Kafka broker until plugin is enabled.